### PR TITLE
build: resolve undefined operation

### DIFF
--- a/pmodeme.cxx
+++ b/pmodeme.cxx
@@ -937,7 +937,7 @@ class ModemEngineBody : public PObject
     void _DetachEngine(ModemClassEngine mce);
     void _ClearCall();
 
-    int NextSeq() { return seq = ++seq & EngineBase::cbpUserDataMask; }
+    int NextSeq() { ++seq; return seq &= EngineBase::cbpUserDataMask; }
 
     ModemEngine &parent;
 


### PR DESCRIPTION
gcc warns:

```
pmodeme.cxx: In member function 'int ModemEngineBody::NextSeq()':
pmodeme.cxx:940:54: warning: operation on
'((ModemEngineBody*)this)->ModemEngineBody::seq' may be undefined
[-Wsequence-point]
     int NextSeq() { return seq = ++seq & EngineBase::cbpUserDataMask; }
```
