### PR TITLE
build: resolve compiler warnings and errors with ptlib-2.18.8

### DIFF
--- a/dle.cxx
+++ b/dle.cxx
@@ -176,7 +176,8 @@ int DLEData::GetDleData(void *pBuf, PINDEX count)
     if (cGet > (PINDEX)sizeof(tmp))
       cGet = sizeof(tmp);
 
-    switch( cGet = GetData(tmp, cGet) ) {
+    int ret = GetData(tmp, cGet);
+    switch (ret) {
       case -1:
         *p++ = DLE;
         *p++ = ETX;

--- a/pmutils.cxx
+++ b/pmutils.cxx
@@ -121,7 +121,7 @@ void ModemThreadChild::SignalStop()
 ///////////////////////////////////////////////////////////////
 int ChunkStream::write(const void *pBuf, PINDEX count)
 {
-  int len = sizeof(data) - last;
+  size_t len = sizeof(data) - last;
 
   if (!len)
     return -1;
@@ -142,7 +142,7 @@ int ChunkStream::read(void *pBuf, PINDEX count)
 
   int len = last - first;
 
-  if (len > count)
+  if (len > 0 && static_cast<size_t>(len) > count)
     len = count;
 
   memcpy(pBuf, data + first, len);


### PR DESCRIPTION
The definition of PINDEX changed in ptlib commit [6629d94fcb3cfd369a9629399a20a217429b4d60](https://sourceforge.net/p/opalvoip/ptlib/ci/6629d94fcb3cfd369a9629399a20a217429b4d60/) .

```
dle.cxx: In member function ‘int DLEData::GetDleData(void*, PINDEX)’:
dle.cxx:180:13: error: narrowing conversion of ‘-1’ from ‘int’ to
‘long unsigned int’ [-Wnarrowing]
  180 |       case -1:
pmutils.cxx: In member function ‘int ChunkStream::write(const void*, PINDEX)’:
pmutils.cxx:129:11: warning: comparison of integer expressions of
different signedness: ‘int’ and ‘PINDEX’ {aka ‘long unsigned int’} [-Wsign-compare]
  129 |   if (len > count)
pmutils.cxx: In member function ‘int ChunkStream::read(void*, PINDEX)’:
pmutils.cxx:145:11: warning: comparison of integer expressions of
different signedness: ‘int’ and ‘PINDEX’ {aka ‘long unsigned int’} [-Wsign-compare]
  145 |   if (len > count)
```
Not tested, but it builds.